### PR TITLE
fix: HOME 환경변수 미설정으로 인한 git config 실패 수정

### DIFF
--- a/python_dev_env/run.sh
+++ b/python_dev_env/run.sh
@@ -4,6 +4,9 @@ set -e
 set -o pipefail
 FAIL_OK=0
 
+# Ensure HOME is set (HA addon containers may not set it)
+export HOME="${HOME:-/root}"
+
 # Emit failing command before exiting to help diagnose unexpected shutdowns
 trap 'STATUS=$?; CMD=${BASH_COMMAND}; if [ "$FAIL_OK" = "1" ]; then log "Warning: command \"$CMD\" failed with status $STATUS (suppressed)"; else log "FATAL: command \"$CMD\" exited with status $STATUS"; exit $STATUS; fi' ERR
 
@@ -36,7 +39,7 @@ configure_git_identity() {
     if [ "$target_user" = "root" ]; then
         run_cmd=""
     else
-        run_cmd="sudo -u $target_user"
+        run_cmd="sudo -H -u $target_user"
     fi
 
     if [ -n "$GIT_NAME" ]; then
@@ -530,7 +533,7 @@ else
 fi
 
 log "Configuring git to use SSH for GitHub..."
-sudo -u $USERNAME git config --global url."git@github.com:".insteadOf "https://github.com/"
+sudo -H -u $USERNAME git config --global url."git@github.com:".insteadOf "https://github.com/"
 git config --global url."git@github.com:".insteadOf "https://github.com/"
 
 echo 'source /etc/shell/env.sh' >> /root/.zshrc


### PR DESCRIPTION
HA 애드온 컨테이너에서 $HOME이 설정되지 않아 git config --global이
"fatal: $HOME not set" 오류로 실패하는 문제 수정.

- 스크립트 시작 시 HOME=${HOME:-/root} 기본값 설정
- sudo -u를 sudo -H -u로 변경하여 대상 사용자의 HOME 올바르게 설정

https://claude.ai/code/session_016k42pCs1hhKthC2Sf45eYo